### PR TITLE
Remove duplicate cluster role binding definitions

### DIFF
--- a/config/contour/external.yaml
+++ b/config/contour/external.yaml
@@ -1390,19 +1390,6 @@ spec:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: contour
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: contour
-subjects:
-- kind: ServiceAccount
-  name: contour
-  namespace: contour-external
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: contour

--- a/config/contour/internal.yaml
+++ b/config/contour/internal.yaml
@@ -1390,19 +1390,6 @@ spec:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: contour
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: contour
-subjects:
-- kind: ServiceAccount
-  name: contour
-  namespace: contour-internal
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: contour

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -53,7 +53,10 @@ rm -rf $(find vendor/ -path '*/pkg/*_test.go')
 rm -rf $(find vendor/ -path '*/e2e/*_test.go')
 
 function delete_contour_cluster_role_bindings() {
-  sed '/apiVersion/{:a;N;/---/!ba};/kind: ClusterRoleBinding/d'
+# Removes ClusterRoleBinding role object.
+# Limitation: This command relies on input yaml file ending with `---` only for BSD(macOS) version of sed.
+# The behaviour you see is that the yaml block from the last occurence of `---` to the end of file will be deleted.
+  sed -e '/apiVersion: rbac/{' -e ':a' -e 'N' -e '/---/!ba' -e '}' -e '/kind: ClusterRoleBinding/d'
 }
 
 function rewrite_contour_namespace() {

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -52,6 +52,10 @@ rm -rf $(find vendor/ -name 'OWNERS')
 rm -rf $(find vendor/ -path '*/pkg/*_test.go')
 rm -rf $(find vendor/ -path '*/e2e/*_test.go')
 
+function delete_contour_cluster_role_bindings() {
+  sed '/apiVersion/{:a;N;/---/!ba};/kind: ClusterRoleBinding/d'
+}
+
 function rewrite_contour_namespace() {
   sed "s@namespace: projectcontour@namespace: $1@g" \
       | sed "s@name: projectcontour@name: $1@g"
@@ -110,6 +114,7 @@ subjects:
 EOF
 
 KO_DOCKER_REPO=ko.local ko resolve -f ./vendor/github.com/projectcontour/contour/examples/contour/ \
+  | delete_contour_cluster_role_bindings \
   | rewrite_contour_namespace contour-internal \
   | configure_leader_election contour-internal \
   | rewrite_serve_args contour-internal \
@@ -135,6 +140,7 @@ subjects:
 EOF
 
 KO_DOCKER_REPO=ko.local ko resolve -f ./vendor/github.com/projectcontour/contour/examples/contour/ \
+  | delete_contour_cluster_role_bindings \
   | rewrite_contour_namespace contour-external \
   | configure_leader_election contour-external \
   | rewrite_serve_args contour-external \

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -53,10 +53,7 @@ rm -rf $(find vendor/ -path '*/pkg/*_test.go')
 rm -rf $(find vendor/ -path '*/e2e/*_test.go')
 
 function delete_contour_cluster_role_bindings() {
-# Removes ClusterRoleBinding role object.
-# Limitation: This command relies on input yaml file ending with `---` only for BSD(macOS) version of sed.
-# The behaviour you see is that the yaml block from the last occurence of `---` to the end of file will be deleted.
-  sed -e '/apiVersion: rbac/{' -e ':a' -e 'N' -e '/---/!ba' -e '}' -e '/kind: ClusterRoleBinding/d'
+  sed -e '/apiVersion: rbac.authorization.k8s.io/{' -e ':a' -e '${' -e 'p' -e 'd'  -e '}' -e 'N' -e '/---/!ba' -e '/kind: ClusterRoleBinding/d' -e '}'
 }
 
 function rewrite_contour_namespace() {


### PR DESCRIPTION
When creating contour-internal and contour-external, the cluster role
binding from the contour project is left intact. This generates two
copies of the `ClusterRoleBinding`s with the same name pointing to
different subjects. However, this is not needed as we define our own
cluster role bindings for internal and external.

related issue: https://github.com/knative/net-contour/issues/53

/cc @shashwathi 