### PR TITLE
Apply PSP to contour.

### DIFF
--- a/config/contour/envoy-psp.yaml
+++ b/config/contour/envoy-psp.yaml
@@ -1,0 +1,45 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: contour-envoy
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+
+  volumes:
+  - 'emptyDir'
+  - 'configMap'
+  - 'secret'
+
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: contour-envoy-psp
+  labels:
+    serving.knative.dev/release: devel
+rules:
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["contour-envoy"]
+    verbs: ["use"]
+

--- a/config/contour/external.yaml
+++ b/config/contour/external.yaml
@@ -11,6 +11,35 @@ subjects:
   name: contour
   namespace: contour-external
 ---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: contour-external-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-serving-psp
+subjects:
+- kind: ServiceAccount
+  name: contour
+  namespace: contour-external
+- kind: ServiceAccount
+  name: contour-certgen
+  namespace: contour-external
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: contour-envoy-external-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: contour-envoy-psp
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: contour-external
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -1382,8 +1411,8 @@ spec:
       serviceAccountName: contour-certgen
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
-        runAsGroup: 65534
+        runAsUser: 65532
+        runAsGroup: 65532
   parallelism: 1
   completions: 1
   backoffLimit: 1
@@ -1634,8 +1663,8 @@ spec:
       serviceAccountName: contour
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
-        runAsGroup: 65534
+        runAsUser: 65532
+        runAsGroup: 65532
       volumes:
       - name: contourcert
         secret:

--- a/config/contour/internal.yaml
+++ b/config/contour/internal.yaml
@@ -11,6 +11,35 @@ subjects:
   name: contour
   namespace: contour-internal
 ---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: contour-internal-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-serving-psp
+subjects:
+- kind: ServiceAccount
+  name: contour
+  namespace: contour-internal
+- kind: ServiceAccount
+  name: contour-certgen
+  namespace: contour-internal
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: contour-envoy-internal-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: contour-envoy-psp
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: contour-internal
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -1382,8 +1411,8 @@ spec:
       serviceAccountName: contour-certgen
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
-        runAsGroup: 65534
+        runAsUser: 65532
+        runAsGroup: 65532
   parallelism: 1
   completions: 1
   backoffLimit: 1
@@ -1634,8 +1663,8 @@ spec:
       serviceAccountName: contour
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
-        runAsGroup: 65534
+        runAsUser: 65532
+        runAsGroup: 65532
       volumes:
       - name: contourcert
         secret:

--- a/test/config/100-test-namespace.yaml
+++ b/test/config/100-test-namespace.yaml
@@ -16,3 +16,16 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: serving-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: serving-tests-psp
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: serving-tests
+roleRef:
+  kind: ClusterRole
+  name: knative-serving-psp
+  apiGroup: rbac.authorization.k8s.io

--- a/test/config/200-clusterrole-psp.yaml
+++ b/test/config/200-clusterrole-psp.yaml
@@ -1,0 +1,60 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: knative-serving
+  labels:
+    serving.knative.dev/release: devel
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+
+  volumes:
+  - 'emptyDir'
+  - 'configMap'
+  - 'secret'
+
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-psp
+  labels:
+    serving.knative.dev/release: devel
+    serving.knative.dev/controller: "true"
+rules:
+  # Pull the PSP into the aggregated cluster role.
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["knative-serving"]
+    verbs: ["use"]

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -18,7 +18,7 @@ source $(dirname $0)/e2e-common.sh
 
 
 # Script entry point.
-initialize $@  --skip-istio-addon
+initialize $@  --skip-istio-addon --cluster-creation-flag "--enable-pod-security-policy"
 
 go_test_e2e -timeout=20m -parallel=12 \
 	    ./vendor/knative.dev/serving/test/conformance/ingress \


### PR DESCRIPTION
This complements https://github.com/knative/serving/pull/7612 to allow contour + serving to run on a cluster with PSP enabled.

/hold

I want to try enabling this in the e2e cluster before I land this.