### PR TITLE
Do not copy object address into slice directly

### DIFF
--- a/pkg/reconciler/contour/resources/httpproxy.go
+++ b/pkg/reconciler/contour/resources/httpproxy.go
@@ -54,7 +54,8 @@ func MakeHTTPProxies(ctx context.Context, ing *v1alpha1.Ingress, serviceToProtoc
 	hostToTLS := make(map[string]*v1alpha1.IngressTLS, len(ing.Spec.TLS))
 	for _, tls := range ing.Spec.TLS {
 		for _, host := range tls.Hosts {
-			hostToTLS[host] = &tls
+			t := tls
+			hostToTLS[host] = &t
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/7844

This patch changes to stop adding TLS object to the slice
directoy. Since the slice (hostToTLS) has the same TLS objects for all
keys, the current tag route with TLS always fail due to mismatched certs.

e.g. please refer to https://prow.knative.dev/view/gcs/knative-prow/logs/ci-knative-serving-contour-latest/1257824177809788928
```
    TestAutoTLS/SelfSignedPerKsvc/Tag_route: util.go:860: Error making GET request: Get "https://tag1-self-per-ksvc.serving-tests.3365.knative-boskos-42.kn-e2e.dev": x509: certificate is valid for tag2-self-per-ksvc.serving-tests.3365.knative-boskos-42.kn-e2e.dev, not tag1-self-per-ksvc.serving-tests.3365.knative-boskos-42.kn-e2e.dev
```