### PR TITLE
Align test calls with net-istio.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/net-contour
 
-go 1.14
+go 1.13
 
 require (
 	github.com/google/go-cmp v0.4.0

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -21,9 +21,9 @@ source $(dirname $0)/e2e-common.sh
 initialize $@  --skip-istio-addon
 
 go_test_e2e -timeout=20m -parallel=12 \
-	    ./vendor/knative.dev/serving/test/conformance/ingress \
-            `# TODO(#12): TestUpdate is consistently failing.` \
-	     -run="Test[^U]" \
-	    --ingressClass=contour.ingress.networking.knative.dev || fail_test
+  knative.dev/serving/test/conformance/ingress \
+  `# TODO(#12): TestUpdate is consistently failing.` \
+  -run="Test[^U]" \
+  --ingressClass=contour.ingress.networking.knative.dev || fail_test
 
 success

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -140,7 +140,6 @@ github.com/golang/protobuf/ptypes/struct
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/go-cmp v0.4.0
-## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
@@ -195,7 +194,6 @@ github.com/openzipkin/zipkin-go/model
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/projectcontour/contour v1.4.1-0.20200507033955-65d52b253570
-## explicit
 github.com/projectcontour/contour/apis/contour/v1beta1
 github.com/projectcontour/contour/apis/projectcontour/v1
 github.com/projectcontour/contour/cmd/contour
@@ -426,17 +424,14 @@ gopkg.in/alecthomas/kingpin.v2
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.8
-## explicit
 gopkg.in/yaml.v2
 # istio.io/api v0.0.0-20200505181140-d58b531533d4
 istio.io/api/networking/v1alpha3
 # istio.io/client-go v0.0.0-20200505182340-146ba01d5357
-## explicit
 istio.io/client-go/pkg/apis/networking/v1alpha3
 # istio.io/gogo-genproto v0.0.0-20191029161641-f7d19ec0141d
 istio.io/gogo-genproto/googleapis/google/api
 # k8s.io/api v0.18.2 => k8s.io/api v0.16.4
-## explicit
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
@@ -480,7 +475,6 @@ k8s.io/api/storage/v1beta1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 # k8s.io/apimachinery v0.18.2 => k8s.io/apimachinery v0.16.4
-## explicit
 k8s.io/apimachinery/pkg/api/apitesting/fuzzer
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
@@ -529,7 +523,6 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible => k8s.io/client-go v0.16.4
-## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
@@ -797,7 +790,6 @@ k8s.io/utils/pointer
 k8s.io/utils/strings
 k8s.io/utils/trace
 # knative.dev/pkg v0.0.0-20200517014302-3c29a1ce8906
-## explicit
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck
 knative.dev/pkg/apis/duck/v1
@@ -854,7 +846,6 @@ knative.dev/pkg/version
 knative.dev/pkg/webhook
 knative.dev/pkg/webhook/certificates/resources
 # knative.dev/serving v0.14.1-0.20200517182103-333523536ee6
-## explicit
 knative.dev/serving/config/core/configmaps
 knative.dev/serving/pkg/apis/autoscaling
 knative.dev/serving/pkg/apis/autoscaling/v1alpha1
@@ -928,7 +919,6 @@ knative.dev/serving/test/test_images/wsserver
 knative.dev/serving/test/types
 knative.dev/serving/test/v1alpha1
 # knative.dev/test-infra v0.0.0-20200515184601-7a28f47cdbcb
-## explicit
 knative.dev/test-infra/scripts
 # sigs.k8s.io/controller-runtime v0.5.0
 sigs.k8s.io/controller-runtime/pkg/scheme
@@ -936,7 +926,3 @@ sigs.k8s.io/controller-runtime/pkg/scheme
 sigs.k8s.io/service-apis/api/v1alpha1
 # sigs.k8s.io/yaml v1.1.0
 sigs.k8s.io/yaml
-# k8s.io/api => k8s.io/api v0.16.4
-# k8s.io/apimachinery => k8s.io/apimachinery v0.16.4
-# k8s.io/client-go => k8s.io/client-go v0.16.4
-# k8s.io/code-generator => k8s.io/code-generator v0.16.4


### PR DESCRIPTION
This should unblock the integration test failures for now.