### PR TITLE
Keep a copy of test/conformance/ingress instead of keeping in vendor/ dir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.14
 
 require (
 	github.com/google/go-cmp v0.4.0
+	github.com/gorilla/websocket v1.4.0
 	github.com/projectcontour/contour v1.4.1-0.20200507033955-65d52b253570
+	google.golang.org/grpc v1.28.1
 	gopkg.in/yaml.v2 v2.2.8
 	istio.io/client-go v0.0.0-20200505182340-146ba01d5357 // indirect
 	k8s.io/api v0.18.2

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -52,6 +52,14 @@ if (( GO_GET )); then
   go get -d ${FLOATING_DEPS[@]}
 fi
 
+# Create a copy of the knative.dev/serving conformace/ingress test suite.
+go mod vendor
+SERVING_MODULE="$(go list -f '{{.Dir}}' -mod=readonly -m knative.dev/serving)"
+mkdir -p test/conformance/ingress
+rm -rf test/conformance/ingress/*
+rsync -r --no-perms "$SERVING_MODULE"/test/conformance/ingress/ test/conformance/ingress
+
+# Prune modules.
 go mod tidy
 go mod vendor
 

--- a/test/conformance/ingress/README.md
+++ b/test/conformance/ingress/README.md
@@ -1,0 +1,77 @@
+# Test
+
+This directory contains Ingress conformance tests for Knative Ingress resource.
+
+## Environment requirements
+
+### Development tools
+
+1. [`go`](https://golang.org/doc/install): The language `Knative Serving` is
+   built in (1.13 or later)
+1. [`ko`](https://github.com/google/ko): Build tool to setup the environment.
+1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For
+   managing development environments.
+
+### Test environment
+
+1. [A running `Knative Serving` cluster.](../../../DEVELOPMENT.md#prerequisites),
+   with the Ingress implementation of choice installed.
+   ```bash
+   # Set the Ingress class annotation to use in tests.
+   # Some examples:
+   #   export INGRESS_CLASS=gloo.ingress.networking.knative.dev      # Gloo Ingress
+   #   export INGRESS_CLASS=istio.ingress.networking.knative.dev     # Istio Ingress
+   #   export INGRESS_CLASS=kourier.ingress.networking.knative.dev   # Kourier Ingress
+   export INGRESS_CLASS=<your-ingress-class-annotation>
+   ```
+1. Knative Serving source code check out at `${SERVING_ROOT}`. Often this is
+   `$GO_PATH/src/go/knative.dev/serving`. This contains all the tests and the
+   test images.
+   ```bash
+   export SERVING_ROOT=<where-you-checked-out-knative/serving>
+   ```
+1. A docker repo containing [the test images](#test-images) `KO_DOCKER_REPO`:
+   The docker repository to which developer images should be pushed (e.g.
+   `gcr.io/[gcloud-project]`).
+
+   ```bash
+   export KO_DOCKER_REPO=<your-docker-repository>
+   ```
+
+1. The `knative-testing` resources
+
+   ```bash
+   ko apply -f "$SERVING_ROOT/test/config"
+   ```
+
+## Building the test images
+
+Note: this is only required when you run conformance/e2e tests locally with
+`go test` commands.
+
+The [`upload-test-images.sh`](../../upload-test-images.sh) script can be used to
+build and push the test images used by the conformance and e2e tests. The script
+expects your environment to be setup as described in
+[DEVELOPMENT.md](../../../DEVELOPMENT.md#install-requirements).
+
+To run the script for all end to end test images:
+
+```bash
+$SERVING_ROOT/test/upload-test-images.sh
+```
+
+## Running the tests
+
+```bash
+cd "$SERVING_ROOT"
+
+# Set the endpoint of your Ingress installation.
+#
+# For example:
+#    export INGRESS_ENDPOINT="$(minikube ip):31380"
+export INGRESS_ENDPOINT=<your-ingress-ip/url>:<your-ingress-port>
+
+go test -v -tags=e2e -count=1 test/conformance/ingress \
+    --ingressClass="$INGRESS_CLASS" \
+    --ingressendpoint=$INGRESSENDPOINT
+```

--- a/test/conformance/ingress/basic_test.go
+++ b/test/conformance/ingress/basic_test.go
@@ -1,0 +1,98 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// TestBasics verifies that a no frills Ingress exposes a simple Pod/Service via the public load balancer.
+func TestBasics(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	// Create a simple Ingress over the Service.
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	RuntimeRequest(t, client, "http://"+name+".example.com")
+}
+
+// TestBasicsHTTP2 verifies that the same no-frills Ingress over a Service with http/2 configured
+// will see a ProtoMajor of 2.
+func TestBasicsHTTP2(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameH2C)
+	defer cancel()
+
+	// Create a simple Ingress over the Service.
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	ri := RuntimeRequest(t, client, "http://"+name+".example.com")
+	if ri == nil {
+		return
+	}
+
+	if want, got := 2, ri.Request.ProtoMajor; want != got {
+		t.Errorf("ProtoMajor = %d, wanted %d", got, want)
+	}
+}

--- a/test/conformance/ingress/grpc_test.go
+++ b/test/conformance/ingress/grpc_test.go
@@ -1,0 +1,221 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+	ping "knative.dev/serving/test/test_images/grpc-ping/proto"
+)
+
+// TestGRPC verifies that GRPC may be used via a simple Ingress.
+func TestGRPC(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	const suffix = "- pong"
+	name, port, cancel := CreateGRPCService(t, clients, suffix)
+	defer cancel()
+
+	domain := name + ".example.com"
+
+	// Create a simple Ingress over the Service.
+	_, dialCtx, cancel := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{domain},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	conn, err := grpc.Dial(
+		domain+":80",
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return dialCtx(ctx, "unused", addr)
+		}),
+	)
+	if err != nil {
+		t.Fatal("Dial() =", err)
+	}
+	defer conn.Close()
+	pc := ping.NewPingServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	stream, err := pc.PingStream(ctx)
+	if err != nil {
+		t.Fatal("PingStream() =", err)
+	}
+
+	for i := 0; i < 100; i++ {
+		checkGRPCRoundTrip(t, stream, suffix)
+	}
+}
+
+// TestGRPCSplit verifies that websockets may be used across a traffic split.
+func TestGRPCSplit(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	const suffixBlue = "- blue"
+	blueName, bluePort, cancel := CreateGRPCService(t, clients, suffixBlue)
+	defer cancel()
+
+	const suffixGreen = "- green"
+	greenName, greenPort, cancel := CreateGRPCService(t, clients, suffixGreen)
+	defer cancel()
+
+	// The suffixes we expect to see.
+	want := sets.NewString(suffixBlue, suffixGreen)
+
+	// Create a simple Ingress over the Service.
+	name := test.ObjectNameForTest(t)
+	domain := name + ".example.com"
+	_, dialCtx, cancel := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{domain},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      blueName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(bluePort),
+						},
+						Percent: 50,
+					}, {
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      greenName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(greenPort),
+						},
+						Percent: 50,
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	conn, err := grpc.Dial(
+		domain+":80",
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return dialCtx(ctx, "unused", addr)
+		}),
+	)
+	if err != nil {
+		t.Fatal("Dial() =", err)
+	}
+	defer conn.Close()
+	pc := ping.NewPingServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	const maxRequests = 100
+	got := sets.NewString()
+	for i := 0; i < maxRequests; i++ {
+		stream, err := pc.PingStream(ctx)
+		if err != nil {
+			t.Errorf("PingStream() = %v", err)
+			continue
+		}
+
+		suffix := findGRPCSuffix(t, stream)
+		if suffix == "" {
+			continue
+		}
+		got.Insert(suffix)
+
+		for j := 0; j < 10; j++ {
+			checkGRPCRoundTrip(t, stream, suffix)
+		}
+
+		if want.Equal(got) {
+			// Short circuit if we've seen all splits.
+			return
+		}
+	}
+
+	// Us getting here means we haven't seen splits.
+	t.Errorf("(over %d requests) (-want, +got) = %s", maxRequests, cmp.Diff(want, got))
+}
+
+func findGRPCSuffix(t *testing.T, stream ping.PingService_PingStreamClient) string {
+	// Establish the suffix that corresponds to this stream.
+	message := fmt.Sprintf("ping - %d", rand.Intn(1000))
+	if err := stream.Send(&ping.Request{Msg: message}); err != nil {
+		t.Errorf("Error sending request: %v", err)
+		return ""
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Errorf("Error receiving response: %v", err)
+		return ""
+	}
+	gotMsg := resp.Msg
+	if !strings.HasPrefix(gotMsg, message) {
+		t.Errorf("Recv() = %s, wanted %s prefix", gotMsg, message)
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(gotMsg, message))
+}
+
+func checkGRPCRoundTrip(t *testing.T, stream ping.PingService_PingStreamClient, suffix string) {
+	message := fmt.Sprintf("ping - %d", rand.Intn(1000))
+	if err := stream.Send(&ping.Request{Msg: message}); err != nil {
+		t.Errorf("Error sending request: %v", err)
+		return
+	}
+
+	// Read back the echoed message and compared with sent.
+	if resp, err := stream.Recv(); err != nil {
+		t.Errorf("Error receiving response: %v", err)
+	} else if got, want := resp.Msg, message+suffix; got != want {
+		t.Errorf("Recv() = %s, wanted %s", got, want)
+	}
+}

--- a/test/conformance/ingress/headers_test.go
+++ b/test/conformance/ingress/headers_test.go
@@ -1,0 +1,185 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// TestPreSplitSetHeaders verifies that an Ingress that specified AppendHeaders pre-split has the appropriate header(s) set.
+func TestPreSplitSetHeaders(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	const headerName = "Foo-Bar-Baz"
+
+	// Create a simple Ingress over the 10 Services.
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					AppendHeaders: map[string]string{
+						headerName: name,
+					},
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	t.Run("Check without passing header", func(t *testing.T) {
+		ri := RuntimeRequest(t, client, "http://"+name+".example.com")
+		if ri == nil {
+			return
+		}
+
+		if got, want := ri.Request.Headers.Get(headerName), name; got != want {
+			t.Errorf("Headers[%q] = %q, wanted %q", headerName, got, want)
+		}
+	})
+
+	t.Run("Check with passing header", func(t *testing.T) {
+		ri := RuntimeRequest(t, client, "http://"+name+".example.com", func(req *http.Request) {
+			// Specify a value for the header to verify that implementations
+			// use set vs. append semantics.
+			req.Header.Set(headerName, "bogus")
+		})
+		if ri == nil {
+			return
+		}
+
+		if got, want := ri.Request.Headers.Get(headerName), name; got != want {
+			t.Errorf("Headers[%q] = %q, wanted %q", headerName, got, want)
+		}
+	})
+}
+
+// TestPostSplitSetHeaders verifies that an Ingress that specified AppendHeaders post-split has the appropriate header(s) set.
+func TestPostSplitSetHeaders(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	const (
+		headerName  = "Foo-Bar-Baz"
+		splits      = 4
+		maxRequests = 100
+	)
+
+	backends := make([]v1alpha1.IngressBackendSplit, 0, splits)
+	names := sets.NewString()
+	for i := 0; i < splits; i++ {
+		name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+		defer cancel()
+		backends = append(backends, v1alpha1.IngressBackendSplit{
+			IngressBackend: v1alpha1.IngressBackend{
+				ServiceName:      name,
+				ServiceNamespace: test.ServingNamespace,
+				ServicePort:      intstr.FromInt(port),
+			},
+			// Append different headers to each split, which lets us identify
+			// which backend we hit.
+			AppendHeaders: map[string]string{
+				headerName: name,
+			},
+			Percent: 100 / splits,
+		})
+		names.Insert(name)
+	}
+
+	// Create a simple Ingress over the 10 Services.
+	name := test.ObjectNameForTest(t)
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: backends,
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	t.Run("Check without passing header", func(t *testing.T) {
+		// Make enough requests that the likelihood of us seeing each variation is high,
+		// but don't check the distribution of requests, as that isn't the point of this
+		// particular test.
+		seen := sets.NewString()
+		for i := 0; i < maxRequests; i++ {
+			ri := RuntimeRequest(t, client, "http://"+name+".example.com")
+			if ri == nil {
+				return
+			}
+			seen.Insert(ri.Request.Headers.Get(headerName))
+			if seen.Equal(names) {
+				// Short circuit if we've seen all headers.
+				return
+			}
+		}
+		// Us getting here means we haven't seen all headers, print the diff.
+		t.Errorf("(over %d requests) Header[%q] (-want, +got) = %s",
+			maxRequests, headerName, cmp.Diff(names, seen))
+	})
+
+	t.Run("Check with passing header", func(t *testing.T) {
+		// Make enough requests that the likelihood of us seeing each variation is high,
+		// but don't check the distribution of requests, as that isn't the point of this
+		// particular test.
+		seen := sets.NewString()
+		for i := 0; i < maxRequests; i++ {
+			ri := RuntimeRequest(t, client, "http://"+name+".example.com", func(req *http.Request) {
+				// Specify a value for the header to verify that implementations
+				// use set vs. append semantics.
+				req.Header.Set(headerName, "bogus")
+			})
+			if ri == nil {
+				return
+			}
+			seen.Insert(ri.Request.Headers.Get(headerName))
+			if seen.Equal(names) {
+				// Short circuit if we've seen all headers.
+				return
+			}
+		}
+		// Us getting here means we haven't seen all headers, print the diff.
+		t.Errorf("(over %d requests) Header[%q] (-want, +got) = %s",
+			maxRequests, headerName, cmp.Diff(names, seen))
+	})
+}

--- a/test/conformance/ingress/hosts_test.go
+++ b/test/conformance/ingress/hosts_test.go
@@ -1,0 +1,70 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// TestMultipleHosts verifies that an Ingress can respond to multiple hosts.
+func TestMultipleHosts(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	// TODO(mattmoor): Once .svc.cluster.local stops being a special case
+	// for Visibility, add it here.
+	hosts := []string{
+		"foo.com",
+		"www.foo.com",
+		"a-b-1.something-really-really-long.knative.dev",
+		"add.your.interesting.domain.here.io",
+	}
+
+	// Create a simple Ingress over the Service.
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      hosts,
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	for _, host := range hosts {
+		RuntimeRequest(t, client, "http://"+host)
+	}
+}

--- a/test/conformance/ingress/path_test.go
+++ b/test/conformance/ingress/path_test.go
@@ -1,0 +1,251 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/pool"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// TestPath verifies that an Ingress properly dispatches to backends based on the path of the URL.
+func TestPath(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	// For /foo
+	fooName, fooPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	// For /bar
+	barName, barPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	// For /baz
+	bazName, bazPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	// Use a post-split injected header to establish which split we are sending traffic to.
+	const headerName = "Which-Backend"
+
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Path: "/foo",
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      fooName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(fooPort),
+						},
+						// Append different headers to each split, which lets us identify
+						// which backend we hit.
+						AppendHeaders: map[string]string{
+							headerName: fooName,
+						},
+						Percent: 100,
+					}},
+				}, {
+					Path: "/bar",
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      barName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(barPort),
+						},
+						// Append different headers to each split, which lets us identify
+						// which backend we hit.
+						AppendHeaders: map[string]string{
+							headerName: barName,
+						},
+						Percent: 100,
+					}},
+				}, {
+					Path: "/baz",
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      bazName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(bazPort),
+						},
+						// Append different headers to each split, which lets us identify
+						// which backend we hit.
+						AppendHeaders: map[string]string{
+							headerName: bazName,
+						},
+						Percent: 100,
+					}},
+				}, {
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+						// Append different headers to each split, which lets us identify
+						// which backend we hit.
+						AppendHeaders: map[string]string{
+							headerName: name,
+						},
+						Percent: 100,
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	tests := map[string]string{
+		"/foo":  fooName,
+		"/bar":  barName,
+		"/baz":  bazName,
+		"":      name,
+		"/asdf": name,
+	}
+
+	for path, want := range tests {
+		t.Run(path, func(t *testing.T) {
+			ri := RuntimeRequest(t, client, "http://"+name+".example.com"+path)
+			if ri == nil {
+				return
+			}
+
+			got := ri.Request.Headers.Get(headerName)
+			if got != want {
+				t.Errorf("Header[%q] = %q, wanted %q", headerName, got, want)
+			}
+		})
+	}
+}
+
+func TestPathAndPercentageSplit(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	fooName, fooPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	barName, barPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	// Use a post-split injected header to establish which split we are sending traffic to.
+	const headerName = "Which-Backend"
+
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Path: "/foo",
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      fooName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(fooPort),
+						},
+						AppendHeaders: map[string]string{
+							headerName: fooName,
+						},
+						Percent: 50,
+					}, {
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      barName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(barPort),
+						},
+						AppendHeaders: map[string]string{
+							headerName: barName,
+						},
+						Percent: 50,
+					}},
+				}, {
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+						// Append different headers to each split, which lets us identify
+						// which backend we hit.
+						AppendHeaders: map[string]string{
+							headerName: name,
+						},
+						Percent: 100,
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	const (
+		total     = 1000
+		totalHalf = total / 2
+		tolerance = total * 0.15
+	)
+	wantKeys := sets.NewString(fooName, barName)
+	resultCh := make(chan string, total)
+
+	wg := pool.New(8)
+
+	for i := 0; i < total; i++ {
+		wg.Go(func() error {
+			ri := RuntimeRequest(t, client, "http://"+name+".example.com/foo")
+			if ri == nil {
+				return errors.New("failed to request")
+			}
+			resultCh <- ri.Request.Headers.Get(headerName)
+			return nil
+		})
+	}
+	if err := wg.Wait(); err != nil {
+		t.Errorf("Error while sending requests: %v", err)
+	}
+	close(resultCh)
+
+	got := make(map[string]float64, len(wantKeys))
+	for r := range resultCh {
+		got[r]++
+	}
+	for k, v := range got {
+		if !wantKeys.Has(k) {
+			t.Errorf("%s is not in the expected header say %v", k, wantKeys)
+		}
+		if math.Abs(v-totalHalf) > tolerance {
+			t.Errorf("Header %s got: %v times, want in [%v, %v] range", k, v, totalHalf-tolerance, totalHalf+tolerance)
+		}
+	}
+}

--- a/test/conformance/ingress/percentage_test.go
+++ b/test/conformance/ingress/percentage_test.go
@@ -1,0 +1,135 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/pool"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// TestPercentage verifies that an Ingress splitting over multiple backends respects
+// the given percentage distribution.
+func TestPercentage(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	// Use a post-split injected header to establish which split we are sending traffic to.
+	const headerName = "Foo-Bar-Baz"
+
+	backends := make([]v1alpha1.IngressBackendSplit, 0, 10)
+	weights := make(map[string]float64, len(backends))
+
+	// Double the percentage of the split each iteration until it would overflow, and then
+	// give the last route the remainder.
+	percent, total := 1, 0
+	for i := 0; i < 10; i++ {
+		name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+		defer cancel()
+		backends = append(backends, v1alpha1.IngressBackendSplit{
+			IngressBackend: v1alpha1.IngressBackend{
+				ServiceName:      name,
+				ServiceNamespace: test.ServingNamespace,
+				ServicePort:      intstr.FromInt(port),
+			},
+			// Append different headers to each split, which lets us identify
+			// which backend we hit.
+			AppendHeaders: map[string]string{
+				headerName: name,
+			},
+			Percent: percent,
+		})
+		weights[name] = float64(percent)
+
+		total += percent
+		percent *= 2
+		// Cap the final non-zero bucket so that we total 100%
+		// After that, this will zero out remaining buckets.
+		if total+percent > 100 {
+			percent = 100 - total
+		}
+	}
+
+	// Create a simple Ingress over the 10 Services.
+	name := test.ObjectNameForTest(t)
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: backends,
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	// Create a large enough population of requests that we can reasonably assess how
+	// well the Ingress respected the percentage split.
+	seen := make(map[string]float64, len(backends))
+
+	const (
+		// The total number of requests to make (as a float to avoid conversions in later computations).
+		totalRequests = 1000.0
+		// The increment to make for each request, so that the values of seen reflect the
+		// percentage of the total number of requests we are making.
+		increment = 100.0 / totalRequests
+		// Allow the Ingress to be within 10% of the configured value.
+		margin = 10.0
+	)
+	wg := pool.New(8)
+	resultCh := make(chan string, totalRequests)
+
+	for i := 0.0; i < totalRequests; i++ {
+		wg.Go(func() error {
+			ri := RuntimeRequest(t, client, "http://"+name+".example.com")
+			if ri == nil {
+				return errors.New("failed to request")
+			}
+			resultCh <- ri.Request.Headers.Get(headerName)
+			return nil
+		})
+	}
+	if err := wg.Wait(); err != nil {
+		t.Errorf("Error while sending requests: %v", err)
+	}
+	close(resultCh)
+
+	for r := range resultCh {
+		seen[r] += increment
+	}
+
+	for name, want := range weights {
+		got := seen[name]
+		switch {
+		case want == 0.0 && got > 0.0:
+			// For 0% targets, we have tighter requirements.
+			t.Errorf("Target %q received traffic, wanted none (0%% target).", name)
+		case math.Abs(got-want) > margin:
+			t.Errorf("Target %q received %f%%, wanted %f +/- %f", name, got, want, margin)
+		}
+	}
+}

--- a/test/conformance/ingress/retry_test.go
+++ b/test/conformance/ingress/retry_test.go
@@ -1,0 +1,140 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// TestRetry verifies that an Ingress configured to retry N times properly masks transient failures.
+func TestRetry(t *testing.T) {
+	for i := 2; i < 12; i++ {
+		i := i
+		t.Run(fmt.Sprintf("period=%d,attempts=%d", i, i), func(t *testing.T) {
+			t.Parallel()
+			clients := test.Setup(t)
+			// When the period matches, then it shouldn't fail.
+			name, port, cancel := CreateFlakyService(t, clients, i)
+			defer cancel()
+
+			domain := name + ".example.com"
+
+			// Create a simple Ingress over the Service.
+			_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{domain},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Retries: retries(i),
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName:      name,
+									ServiceNamespace: test.ServingNamespace,
+									ServicePort:      intstr.FromInt(port),
+								},
+							}},
+						}},
+					},
+				}},
+			})
+			defer cancel()
+
+			for j := 0; j < 5; j++ {
+				resp, err := client.Get("http://" + domain)
+				if err != nil {
+					t.Errorf("Error making GET request: %v", err)
+					continue
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					t.Errorf("Got non-OK status: %d", resp.StatusCode)
+					DumpResponse(t, resp)
+				}
+			}
+		})
+
+		t.Run(fmt.Sprintf("period=%d,attempts=%d", i, i-1), func(t *testing.T) {
+			t.Parallel()
+			clients := test.Setup(t)
+			// When the period matches, then it shouldn't fail.
+			name, port, cancel := CreateFlakyService(t, clients, i)
+			defer cancel()
+
+			domain := name + ".example.com"
+
+			// Create a simple Ingress over the Service.
+			_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+				Rules: []v1alpha1.IngressRule{{
+					Hosts:      []string{domain},
+					Visibility: v1alpha1.IngressVisibilityExternalIP,
+					HTTP: &v1alpha1.HTTPIngressRuleValue{
+						Paths: []v1alpha1.HTTPIngressPath{{
+							Retries: retries(i - 1),
+							Splits: []v1alpha1.IngressBackendSplit{{
+								IngressBackend: v1alpha1.IngressBackend{
+									ServiceName:      name,
+									ServiceNamespace: test.ServingNamespace,
+									ServicePort:      intstr.FromInt(port),
+								},
+							}},
+						}},
+					},
+				}},
+			})
+			defer cancel()
+
+			// When the period is one more than the number of attempts (retries+1), then what we should see is:
+			//   500 {count=4}
+			//   200 {count=5}
+			//   500 {count=9}
+			//   200 {count=10}
+			//   500 {count=14}
+			//   200 {count=15}
+			current, next := http.StatusInternalServerError, http.StatusOK
+			for j := 0; j < 5; j++ {
+				resp, err := client.Get("http://" + domain)
+				if err != nil {
+					t.Errorf("Error making GET request: %v", err)
+					continue
+				}
+				defer resp.Body.Close()
+				if want, got := current, resp.StatusCode; got != want {
+					t.Errorf("Status = %d, wanted %d", got, want)
+					DumpResponse(t, resp)
+				}
+				// Swap things.
+				current, next = next, current
+			}
+		})
+	}
+}
+
+func retries(attempts int) *v1alpha1.HTTPRetry {
+	return &v1alpha1.HTTPRetry{
+		// retries is one less than the number of attempts
+		Attempts: attempts - 1,
+	}
+}

--- a/test/conformance/ingress/timeout_test.go
+++ b/test/conformance/ingress/timeout_test.go
@@ -1,0 +1,111 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// TestTimeout verifies that an Ingress configured with a timeout respects that.
+func TestTimeout(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	name, port, cancel := CreateTimeoutService(t, clients)
+	defer cancel()
+
+	// The timeout, and an epsilon value to use as jitter for testing requests
+	// either hit or miss the timeout (without getting so close that we flake).
+	const (
+		timeout = 1 * time.Second
+		epsilon = 100 * time.Millisecond
+	)
+
+	// Create a simple Ingress over the Service.
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{name + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Timeout: &metav1.Duration{Duration: timeout},
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	tests := []struct {
+		name         string
+		code         int
+		initialDelay time.Duration
+		delay        time.Duration
+	}{{
+		name: "no delays is OK",
+		code: http.StatusOK,
+	}, {
+		name:  "large delay after headers is ok",
+		code:  http.StatusOK,
+		delay: timeout + timeout,
+	}, {
+		name:         "initial delay less than timeout is ok",
+		code:         http.StatusOK,
+		initialDelay: timeout - epsilon,
+	}, {
+		name:         "initial delay over timeout is NOT ok",
+		code:         http.StatusGatewayTimeout,
+		initialDelay: timeout + epsilon,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			checkTimeout(t, client, name, test.code, test.initialDelay, test.delay)
+		})
+	}
+}
+
+func checkTimeout(t *testing.T, client *http.Client, name string, code int, initial time.Duration, timeout time.Duration) {
+	t.Helper()
+
+	resp, err := client.Get(fmt.Sprintf("http://%s.example.com?initialTimeout=%d&timeout=%d",
+		name, initial.Milliseconds(), timeout.Milliseconds()))
+	if err != nil {
+		t.Fatal("Error making GET request:", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != code {
+		t.Errorf("Unexpected status code: %d, wanted %d", resp.StatusCode, code)
+		DumpResponse(t, resp)
+	}
+}

--- a/test/conformance/ingress/tls_test.go
+++ b/test/conformance/ingress/tls_test.go
@@ -1,0 +1,76 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// TestIngressTLS verifies that the Ingress properly handles the TLS field.
+func TestIngressTLS(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	hosts := []string{name + ".example.com"}
+
+	secretName, cancel := CreateTLSSecret(t, clients, hosts)
+	defer cancel()
+
+	_, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      hosts,
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+		TLS: []v1alpha1.IngressTLS{{
+			Hosts:           hosts,
+			SecretName:      secretName,
+			SecretNamespace: test.ServingNamespace,
+		}},
+	})
+	defer cancel()
+
+	t.Run("verify HTTP", func(t *testing.T) {
+		RuntimeRequest(t, client, "http://"+name+".example.com")
+	})
+
+	t.Run("verify HTTPS", func(t *testing.T) {
+		RuntimeRequest(t, client, "https://"+name+".example.com")
+	})
+}
+
+// TODO(mattmoor): Consider adding variants where we have multiple hosts with distinct certificates.

--- a/test/conformance/ingress/update_test.go
+++ b/test/conformance/ingress/update_test.go
@@ -1,0 +1,204 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// Header to disambiguate what version we're talking to.
+const updateHeaderName = "Who-Are-You"
+
+// TestUpdate verifies that when the network programming changes that traffic isn't dropped.
+func TestUpdate(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	firstName, firstPort, firstCancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+
+	// Create a simple Ingress over the Service.
+	hostname := test.ObjectNameForTest(t)
+	ing, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{hostname + ".example.com"},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      firstName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(firstPort),
+						},
+						// Append different headers to each split, which lets us identify
+						// which backend we hit.
+						AppendHeaders: map[string]string{
+							updateHeaderName: firstName,
+						},
+					}},
+				}},
+			},
+		}},
+	})
+
+	previousVersionCancel := func() {
+		t.Logf("Tearing down %q", firstName)
+		firstCancel()
+	}
+
+	proberCancel := checkOK(t, "http://"+hostname+".example.com", client)
+	defer func() {
+		proberCancel()
+		previousVersionCancel()
+		cancel()
+	}()
+
+	// Give the prober a chance to get started.
+	time.Sleep(1 * time.Second)
+
+	// First test with only sentinel changes.
+	for i := 0; i < 10; i++ {
+		sentinel := test.ObjectNameForTest(t)
+
+		t.Logf("Rolling out %q w/ %q", firstName, sentinel)
+
+		// Update the Ingress, and wait for it to report ready.
+		UpdateIngressReady(t, clients, ing.Name, v1alpha1.IngressSpec{
+			Rules: []v1alpha1.IngressRule{{
+				Hosts:      []string{hostname + ".example.com"},
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
+				HTTP: &v1alpha1.HTTPIngressRuleValue{
+					Paths: []v1alpha1.HTTPIngressPath{{
+						Splits: []v1alpha1.IngressBackendSplit{{
+							IngressBackend: v1alpha1.IngressBackend{
+								ServiceName:      firstName,
+								ServiceNamespace: test.ServingNamespace,
+								ServicePort:      intstr.FromInt(firstPort),
+							},
+							AppendHeaders: map[string]string{
+								updateHeaderName: sentinel,
+							},
+						}},
+					}},
+				},
+			}},
+		})
+
+		// Check that it serves the right message as soon as we get "Ready",
+		// but before we stop probing.
+		ri := RuntimeRequest(t, client, "http://"+hostname+".example.com")
+		if ri != nil {
+			if got := ri.Request.Headers.Get(updateHeaderName); got != sentinel {
+				t.Errorf("Header[%q] = %q, wanted %q", updateHeaderName, got, sentinel)
+			}
+		}
+	}
+
+	// Next test with varying sentinels AND fresh services each time.
+	previousVersionCancel = func() {
+		t.Logf("Tearing down %q", firstName)
+		firstCancel()
+	}
+	for i := 0; i < 10; i++ {
+		sentinel := test.ObjectNameForTest(t)
+		nextName, nextPort, nextCancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+
+		t.Logf("Rolling out %q w/ %q", nextName, sentinel)
+
+		// Update the Ingress, and wait for it to report ready.
+		UpdateIngressReady(t, clients, ing.Name, v1alpha1.IngressSpec{
+			Rules: []v1alpha1.IngressRule{{
+				Hosts:      []string{hostname + ".example.com"},
+				Visibility: v1alpha1.IngressVisibilityExternalIP,
+				HTTP: &v1alpha1.HTTPIngressRuleValue{
+					Paths: []v1alpha1.HTTPIngressPath{{
+						Splits: []v1alpha1.IngressBackendSplit{{
+							IngressBackend: v1alpha1.IngressBackend{
+								ServiceName:      nextName,
+								ServiceNamespace: test.ServingNamespace,
+								ServicePort:      intstr.FromInt(nextPort),
+							},
+							AppendHeaders: map[string]string{
+								updateHeaderName: sentinel,
+							},
+						}},
+					}},
+				},
+			}},
+		})
+
+		// Check that it serves the right message as soon as we get "Ready",
+		// but before we stop probing.
+		ri := RuntimeRequest(t, client, "http://"+hostname+".example.com")
+		if ri != nil {
+			if got := ri.Request.Headers.Get(updateHeaderName); got != sentinel {
+				t.Errorf("Header[%q] = %q, wanted %q", updateHeaderName, got, sentinel)
+			}
+		}
+
+		// Once we've rolled out, cancel the previous version.
+		previousVersionCancel()
+		// Then make ourselves the next to be cancelled.
+		previousVersionCancel = func() {
+			t.Logf("Tearing down %q", nextName)
+			nextCancel()
+		}
+	}
+}
+
+func checkOK(t *testing.T, url string, client *http.Client) context.CancelFunc {
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+
+	// Launch the prober
+	go func() {
+		defer close(doneCh)
+		for {
+			// Each iteration check for cancellation.
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+			// Scope the defer below to avoid leaking until the test completes.
+			func() {
+				ri := RuntimeRequest(t, client, url)
+				if ri != nil {
+					// Use the updateHeaderName as a debug marker to identify which version
+					// (of programming) is responding.
+					t.Logf("[%s] Got OK status!", ri.Request.Headers.Get(updateHeaderName))
+				}
+			}()
+		}
+	}()
+
+	// Return a cancel function that stops the prober and then waits for it to complete.
+	return func() {
+		close(stopCh)
+		<-doneCh
+	}
+}

--- a/test/conformance/ingress/util.go
+++ b/test/conformance/ingress/util.go
@@ -1,0 +1,947 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	cryptorand "crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/pkg/network"
+	pkgTest "knative.dev/pkg/test"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+	"knative.dev/serving/test/types"
+	v1a1test "knative.dev/serving/test/v1alpha1"
+)
+
+var rootCAs = x509.NewCertPool()
+
+var dialBackoff = wait.Backoff{
+	Duration: 50 * time.Millisecond,
+	Factor:   1.4,
+	Jitter:   0.1, // At most 10% jitter.
+	Steps:    100,
+	Cap:      10 * time.Second,
+}
+
+// uaRoundTripper wraps the given http.RoundTripper and
+// sets a custom UserAgent.
+type uaRoundTripper struct {
+	http.RoundTripper
+	ua string
+}
+
+// RoundTrip implements http.RoundTripper.
+func (ua *uaRoundTripper) RoundTrip(rq *http.Request) (*http.Response, error) {
+	rq.Header.Set("User-Agent", ua.ua)
+	return ua.RoundTripper.RoundTrip(rq)
+}
+
+// CreateRuntimeService creates a Kubernetes service that will respond to the protocol
+// specified with the given portName.  It returns the service name, the port on
+// which the service is listening, and a "cancel" function to clean up the
+// created resources.
+func CreateRuntimeService(t *testing.T, clients *test.Clients, portName string) (string, int, context.CancelFunc) {
+	t.Helper()
+	name := test.ObjectNameForTest(t)
+
+	// Avoid zero, but pick a low port number.
+	port := 50 + rand.Intn(50)
+	t.Logf("[%s] Using port %d", name, port)
+
+	// Pick a high port number.
+	containerPort := 8000 + rand.Intn(100)
+	t.Logf("[%s] Using containerPort %d", name, containerPort)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "foo",
+				Image: pkgTest.ImagePath("runtime"),
+				Ports: []corev1.ContainerPort{{
+					Name:          portName,
+					ContainerPort: int32(containerPort),
+				}},
+				// This is needed by the runtime image we are using.
+				Env: []corev1.EnvVar{{
+					Name:  "PORT",
+					Value: strconv.Itoa(containerPort),
+				}},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/healthz",
+							Port: intstr.FromInt(containerPort),
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{{
+				Name:       portName,
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(containerPort),
+			}},
+			Selector: map[string]string{
+				"test-pod": name,
+			},
+		},
+	}
+
+	return name, port, createPodAndService(t, clients, pod, svc)
+}
+
+// CreateProxyService creates a Kubernetes service that will forward requests to
+// the specified target.  It returns the service name, the port on which the service
+// is listening, and a "cancel" function to clean up the created resources.
+func CreateProxyService(t *testing.T, clients *test.Clients, target string, gatewayDomain string) (string, int, context.CancelFunc) {
+	t.Helper()
+	name := test.ObjectNameForTest(t)
+
+	// Avoid zero, but pick a low port number.
+	port := 50 + rand.Intn(50)
+	t.Logf("[%s] Using port %d", name, port)
+
+	// Pick a high port number.
+	containerPort := 8000 + rand.Intn(100)
+	t.Logf("[%s] Using containerPort %d", name, containerPort)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "foo",
+				Image: pkgTest.ImagePath("httpproxy"),
+				Ports: []corev1.ContainerPort{{
+					ContainerPort: int32(containerPort),
+				}},
+				Env: []corev1.EnvVar{{
+					Name:  "TARGET_HOST",
+					Value: target,
+				}, {
+					Name:  "PORT",
+					Value: strconv.Itoa(containerPort),
+				}},
+			}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{{
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(containerPort),
+			}},
+			Selector: map[string]string{
+				"test-pod": name,
+			},
+		},
+	}
+	proxyServiceCancel := createPodAndService(t, clients, pod, svc)
+
+	targetName := strings.Split(target, ".")
+	externalNameSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      targetName[0],
+			Namespace: targetName[1],
+		},
+		Spec: corev1.ServiceSpec{
+			Type:            corev1.ServiceTypeExternalName,
+			ExternalName:    gatewayDomain,
+			SessionAffinity: corev1.ServiceAffinityNone,
+		},
+	}
+
+	externalNameServiceCancel := createService(t, clients, externalNameSvc)
+
+	return name, port, func() {
+		externalNameServiceCancel()
+		proxyServiceCancel()
+	}
+}
+
+// CreateTimeoutService creates a Kubernetes service that will respond to the protocol
+// specified with the given portName.  It returns the service name, the port on
+// which the service is listening, and a "cancel" function to clean up the
+// created resources.
+func CreateTimeoutService(t *testing.T, clients *test.Clients) (string, int, context.CancelFunc) {
+	t.Helper()
+	name := test.ObjectNameForTest(t)
+
+	// Avoid zero, but pick a low port number.
+	port := 50 + rand.Intn(50)
+	t.Logf("[%s] Using port %d", name, port)
+
+	// Pick a high port number.
+	containerPort := 8000 + rand.Intn(100)
+	t.Logf("[%s] Using containerPort %d", name, containerPort)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "foo",
+				Image: pkgTest.ImagePath("timeout"),
+				Ports: []corev1.ContainerPort{{
+					Name:          networking.ServicePortNameHTTP1,
+					ContainerPort: int32(containerPort),
+				}},
+				// This is needed by the timeout image we are using.
+				Env: []corev1.EnvVar{{
+					Name:  "PORT",
+					Value: strconv.Itoa(containerPort),
+				}},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Port: intstr.FromInt(containerPort),
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameHTTP1,
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(containerPort),
+			}},
+			Selector: map[string]string{
+				"test-pod": name,
+			},
+		},
+	}
+
+	return name, port, createPodAndService(t, clients, pod, svc)
+}
+
+// CreateFlakyService creates a Kubernetes service where the backing pod will
+// succeed only every Nth request.
+func CreateFlakyService(t *testing.T, clients *test.Clients, period int) (string, int, context.CancelFunc) {
+	t.Helper()
+	name := test.ObjectNameForTest(t)
+
+	// Avoid zero, but pick a low port number.
+	port := 50 + rand.Intn(50)
+	t.Logf("[%s] Using port %d", name, port)
+
+	// Pick a high port number.
+	containerPort := 8000 + rand.Intn(100)
+	t.Logf("[%s] Using containerPort %d", name, containerPort)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "foo",
+				Image: pkgTest.ImagePath("flaky"),
+				Ports: []corev1.ContainerPort{{
+					Name:          networking.ServicePortNameHTTP1,
+					ContainerPort: int32(containerPort),
+				}},
+				// This is needed by the runtime image we are using.
+				Env: []corev1.EnvVar{{
+					Name:  "PORT",
+					Value: strconv.Itoa(containerPort),
+				}, {
+					Name:  "PERIOD",
+					Value: strconv.Itoa(period),
+				}},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/",
+							Port: intstr.FromInt(containerPort),
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameHTTP1,
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(containerPort),
+			}},
+			Selector: map[string]string{
+				"test-pod": name,
+			},
+		},
+	}
+
+	return name, port, createPodAndService(t, clients, pod, svc)
+}
+
+// CreateWebsocketService creates a Kubernetes service that will upgrade the connection
+// to use websockets and echo back the received messages with the provided suffix.
+func CreateWebsocketService(t *testing.T, clients *test.Clients, suffix string) (string, int, context.CancelFunc) {
+	t.Helper()
+	name := test.ObjectNameForTest(t)
+
+	// Avoid zero, but pick a low port number.
+	port := 50 + rand.Intn(50)
+	t.Logf("[%s] Using port %d", name, port)
+
+	// Pick a high port number.
+	containerPort := 8000 + rand.Intn(100)
+	t.Logf("[%s] Using containerPort %d", name, containerPort)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "foo",
+				Image: pkgTest.ImagePath("wsserver"),
+				Ports: []corev1.ContainerPort{{
+					Name:          networking.ServicePortNameHTTP1,
+					ContainerPort: int32(containerPort),
+				}},
+				// This is needed by the runtime image we are using.
+				Env: []corev1.EnvVar{{
+					Name:  "PORT",
+					Value: strconv.Itoa(containerPort),
+				}, {
+					Name:  "SUFFIX",
+					Value: suffix,
+				}},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path: "/",
+							Port: intstr.FromInt(containerPort),
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameHTTP1,
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(containerPort),
+			}},
+			Selector: map[string]string{
+				"test-pod": name,
+			},
+		},
+	}
+
+	return name, port, createPodAndService(t, clients, pod, svc)
+}
+
+// CreateGRPCService creates a Kubernetes service that will upgrade the connection
+// to use GRPC and echo back the received messages with the provided suffix.
+func CreateGRPCService(t *testing.T, clients *test.Clients, suffix string) (string, int, context.CancelFunc) {
+	t.Helper()
+	name := test.ObjectNameForTest(t)
+
+	// Avoid zero, but pick a low port number.
+	port := 50 + rand.Intn(50)
+	t.Logf("[%s] Using port %d", name, port)
+
+	// Pick a high port number.
+	containerPort := 8000 + rand.Intn(100)
+	t.Logf("[%s] Using containerPort %d", name, containerPort)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "foo",
+				Image: pkgTest.ImagePath("grpc-ping"),
+				Ports: []corev1.ContainerPort{{
+					Name:          networking.ServicePortNameH2C,
+					ContainerPort: int32(containerPort),
+				}},
+				// This is needed by the runtime image we are using.
+				Env: []corev1.EnvVar{{
+					Name:  "PORT",
+					Value: strconv.Itoa(containerPort),
+				}, {
+					Name:  "SUFFIX",
+					Value: suffix,
+				}},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						TCPSocket: &corev1.TCPSocketAction{
+							Port: intstr.FromInt(containerPort),
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Labels: map[string]string{
+				"test-pod": name,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: "ClusterIP",
+			Ports: []corev1.ServicePort{{
+				Name:       networking.ServicePortNameH2C,
+				Port:       int32(port),
+				TargetPort: intstr.FromInt(containerPort),
+			}},
+			Selector: map[string]string{
+				"test-pod": name,
+			},
+		},
+	}
+
+	return name, port, createPodAndService(t, clients, pod, svc)
+}
+
+// createService is a helper for creating the service resource.
+func createService(t *testing.T, clients *test.Clients, svc *corev1.Service) context.CancelFunc {
+	t.Helper()
+
+	test.CleanupOnInterrupt(func() {
+		clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Delete(svc.Name, &metav1.DeleteOptions{})
+	})
+	svc, err := clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Create(svc)
+	if err != nil {
+		t.Fatal("Error creating Service:", err)
+	}
+
+	return func() {
+		err := clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Delete(svc.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			t.Errorf("Error cleaning up Service %s: %v", svc.Name, err)
+		}
+	}
+}
+
+// createPodAndService is a helper for creating the pod and service resources, setting
+// up their context.CancelFunc, and waiting for it to become ready.
+func createPodAndService(t *testing.T, clients *test.Clients, pod *corev1.Pod, svc *corev1.Service) context.CancelFunc {
+	t.Helper()
+
+	test.CleanupOnInterrupt(func() { clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{}) })
+	pod, err := clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Create(pod)
+	if err != nil {
+		t.Fatal("Error creating Pod:", err)
+	}
+	cancel := func() {
+		err := clients.KubeClient.Kube.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			t.Errorf("Error cleaning up Pod %s", pod.Name)
+		}
+	}
+
+	test.CleanupOnInterrupt(func() {
+		clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Delete(svc.Name, &metav1.DeleteOptions{})
+	})
+	svc, err = clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Create(svc)
+	if err != nil {
+		cancel()
+		t.Fatal("Error creating Service:", err)
+	}
+
+	// Wait for the Pod to show up in the Endpoints resource.
+	waitErr := wait.PollImmediate(test.PollInterval, test.PollTimeout, func() (bool, error) {
+		ep, err := clients.KubeClient.Kube.CoreV1().Endpoints(svc.Namespace).Get(svc.Name, metav1.GetOptions{})
+		if apierrs.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return true, err
+		}
+		for _, subset := range ep.Subsets {
+			if len(subset.Addresses) == 0 {
+				return false, nil
+			}
+		}
+		return len(ep.Subsets) > 0, nil
+	})
+	if waitErr != nil {
+		cancel()
+		t.Fatal("Error waiting for Endpoints to contain a Pod IP:", waitErr)
+	}
+
+	return func() {
+		err := clients.KubeClient.Kube.CoreV1().Services(svc.Namespace).Delete(svc.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			t.Errorf("Error cleaning up Service %s: %v", svc.Name, err)
+		}
+		cancel()
+	}
+}
+
+// CreateIngress creates a Knative Ingress resource
+func CreateIngress(t *testing.T, clients *test.Clients, spec v1alpha1.IngressSpec) (*v1alpha1.Ingress, context.CancelFunc) {
+	t.Helper()
+
+	name := test.ObjectNameForTest(t)
+
+	// Create a simple Ingress over the Service.
+	ing := &v1alpha1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.ServingNamespace,
+			Annotations: map[string]string{
+				networking.IngressClassAnnotationKey: test.ServingFlags.IngressClass,
+			},
+		},
+		Spec: spec,
+	}
+	test.CleanupOnInterrupt(func() { clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{}) })
+	ing, err := clients.NetworkingClient.Ingresses.Create(ing)
+	if err != nil {
+		t.Fatal("Error creating Ingress:", err)
+	}
+
+	return ing, func() {
+		err := clients.NetworkingClient.Ingresses.Delete(ing.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			t.Errorf("Error cleaning up Ingress %s: %v", ing.Name, err)
+		}
+	}
+}
+
+func CreateIngressReadyDialContext(t *testing.T, clients *test.Clients, spec v1alpha1.IngressSpec) (*v1alpha1.Ingress, func(context.Context, string, string) (net.Conn, error), context.CancelFunc) {
+	t.Helper()
+	ing, cancel := CreateIngress(t, clients, spec)
+
+	if err := v1a1test.WaitForIngressState(clients.NetworkingClient, ing.Name, v1a1test.IsIngressReady, t.Name()); err != nil {
+		cancel()
+		t.Fatal("Error waiting for ingress state:", err)
+	}
+	ing, err := clients.NetworkingClient.Ingresses.Get(ing.Name, metav1.GetOptions{})
+	if err != nil {
+		cancel()
+		t.Fatal("Error getting Ingress:", err)
+	}
+
+	// Create a dialer based on the Ingress' public load balancer.
+	return ing, CreateDialContext(t, ing, clients), cancel
+}
+
+func CreateIngressReady(t *testing.T, clients *test.Clients, spec v1alpha1.IngressSpec) (*v1alpha1.Ingress, *http.Client, context.CancelFunc) {
+	t.Helper()
+
+	// Create a client with a dialer based on the Ingress' public load balancer.
+	ing, dialer, cancel := CreateIngressReadyDialContext(t, clients, spec)
+
+	// TODO(mattmoor): How to get ing?
+	var tlsConfig *tls.Config
+	if len(ing.Spec.TLS) > 0 {
+		// CAs are added to this as TLS secrets are created.
+		tlsConfig = &tls.Config{
+			RootCAs: rootCAs,
+		}
+	}
+
+	return ing, &http.Client{
+		Transport: &uaRoundTripper{
+			RoundTripper: &http.Transport{
+				DialContext:     dialer,
+				TLSClientConfig: tlsConfig,
+			},
+			ua: fmt.Sprintf("knative.dev/%s/%s", t.Name(), ing.Name),
+		},
+	}, cancel
+}
+
+// UpdateIngress updates a Knative Ingress resource
+func UpdateIngress(t *testing.T, clients *test.Clients, name string, spec v1alpha1.IngressSpec) {
+	t.Helper()
+
+	ing, err := clients.NetworkingClient.Ingresses.Get(name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal("Error getting Ingress:", err)
+	}
+
+	ing.Spec = spec
+	if _, err := clients.NetworkingClient.Ingresses.Update(ing); err != nil {
+		t.Fatal("Error updating Ingress:", err)
+	}
+}
+
+func UpdateIngressReady(t *testing.T, clients *test.Clients, name string, spec v1alpha1.IngressSpec) {
+	t.Helper()
+	UpdateIngress(t, clients, name, spec)
+
+	if err := v1a1test.WaitForIngressState(clients.NetworkingClient, name, v1a1test.IsIngressReady, t.Name()); err != nil {
+		t.Fatal("Error waiting for ingress state:", err)
+	}
+}
+
+// This is based on https://golang.org/src/crypto/tls/generate_cert.go
+func CreateTLSSecret(t *testing.T, clients *test.Clients, hosts []string) (string, context.CancelFunc) {
+	return CreateTLSSecretWithCertPool(t, clients, hosts, test.ServingNamespace, rootCAs)
+}
+
+// CreateTLSSecretWithCertPool creates TLS certificate with given CertPool.
+func CreateTLSSecretWithCertPool(t *testing.T, clients *test.Clients, hosts []string, ns string, cas *x509.CertPool) (string, context.CancelFunc) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
+	if err != nil {
+		t.Fatal("ecdsa.GenerateKey() =", err)
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := cryptorand.Int(cryptorand.Reader, serialNumberLimit)
+	if err != nil {
+		t.Fatal("Failed to generate serial number:", err)
+	}
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Knative Ingress Conformance Testing"},
+		},
+
+		// Only let it live briefly.
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(5 * time.Minute),
+
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+
+		DNSNames: hosts,
+	}
+
+	derBytes, err := x509.CreateCertificate(cryptorand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal("x509.CreateCertificate() =", err)
+	}
+
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		t.Fatal("ParseCertificate() =", err)
+	}
+	// Ideally we'd undo this in "cancel", but there doesn't
+	// seem to be a mechanism to remove things from a pool.
+	cas.AddCert(cert)
+
+	certPEM := &bytes.Buffer{}
+	if err := pem.Encode(certPEM, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
+		t.Fatal("Failed to write data to cert.pem:", err)
+	}
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal("Unable to marshal private key:", err)
+	}
+	privPEM := &bytes.Buffer{}
+	if err := pem.Encode(privPEM, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}); err != nil {
+		t.Fatal("Failed to write data to key.pem:", err)
+	}
+
+	name := test.ObjectNameForTest(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				"test-secret": name,
+			},
+		},
+		Type: corev1.SecretTypeTLS,
+		StringData: map[string]string{
+			corev1.TLSCertKey:       certPEM.String(),
+			corev1.TLSPrivateKeyKey: privPEM.String(),
+		},
+	}
+	test.CleanupOnInterrupt(func() {
+		clients.KubeClient.Kube.CoreV1().Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{})
+	})
+	if _, err := clients.KubeClient.Kube.CoreV1().Secrets(secret.Namespace).Create(secret); err != nil {
+		t.Fatal("Error creating Secret:", err)
+	}
+	return name, func() {
+		err := clients.KubeClient.Kube.CoreV1().Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			t.Errorf("Error cleaning up Secret %s: %v", secret.Name, err)
+		}
+	}
+}
+
+// CreateDialContext looks up the endpoint information to create a "dialer" for
+// the provided Ingress' public ingress loas balancer.  It can be used to
+// contact external-visibility services with an HTTP client via:
+//
+//	client := &http.Client{
+//		Transport: &http.Transport{
+//			DialContext: CreateDialContext(t, ing, clients),
+//		},
+//	}
+func CreateDialContext(t *testing.T, ing *v1alpha1.Ingress, clients *test.Clients) func(context.Context, string, string) (net.Conn, error) {
+	t.Helper()
+	if ing.Status.PublicLoadBalancer == nil || len(ing.Status.PublicLoadBalancer.Ingress) < 1 {
+		t.Fatal("Ingress does not have a public load balancer assigned.")
+	}
+
+	// TODO(mattmoor): I'm open to tricks that would let us cleanly test multiple
+	// public load balancers or LBs with multiple ingresses (below), but want to
+	// keep our simple tests simple, thus the [0]s...
+
+	// We expect an ingress LB with the form foo.bar.svc.cluster.local (though
+	// we aren't strictly sensitive to the suffix, this is just illustrative.
+	internalDomain := ing.Status.PublicLoadBalancer.Ingress[0].DomainInternal
+	parts := strings.SplitN(internalDomain, ".", 3)
+	if len(parts) < 3 {
+		t.Fatal("Too few parts in internal domain:", internalDomain)
+	}
+	name, namespace := parts[0], parts[1]
+
+	svc, err := clients.KubeClient.Kube.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unable to retrieve Kubernetes service %s/%s: %v", namespace, name, err)
+	}
+	if len(svc.Status.LoadBalancer.Ingress) < 1 {
+		t.Fatal("Service does not have any ingresses (not type LoadBalancer?).")
+	}
+	ingress := svc.Status.LoadBalancer.Ingress[0]
+	dial := network.NewBackoffDialer(dialBackoff)
+	return func(ctx context.Context, _ string, address string) (net.Conn, error) {
+		_, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		// Allow "ingressendpoint" flag to override the discovered ingress IP/hostname,
+		// this is required in minikube-like environments.
+		if pkgTest.Flags.IngressEndpoint != "" {
+			return dial(ctx, "tcp", pkgTest.Flags.IngressEndpoint)
+		}
+		if ingress.IP != "" {
+			return dial(ctx, "tcp", ingress.IP+":"+port)
+		}
+		if ingress.Hostname != "" {
+			return dial(ctx, "tcp", ingress.Hostname+":"+port)
+		}
+		return nil, errors.New("service ingress does not contain dialing information")
+	}
+}
+
+type RequestOption func(*http.Request)
+type ResponseExpectation func(response *http.Response) error
+
+func RuntimeRequest(t *testing.T, client *http.Client, url string, opts ...RequestOption) *types.RuntimeInfo {
+	return RuntimeRequestWithExpectations(t, client, url,
+		[]ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusOK))},
+		false,
+		opts...)
+}
+
+// RuntimeRequestWithExpectations attempts to make a request to url and return runtime information.
+// If connection is successful only then it will validate all response expectations.
+// If allowDialError is set to true then function will not fail if connection is a dial error.
+func RuntimeRequestWithExpectations(t *testing.T, client *http.Client, url string,
+	responseExpectations []ResponseExpectation,
+	allowDialError bool,
+	opts ...RequestOption) *types.RuntimeInfo {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Errorf("Error creating Request: %v", err)
+		return nil
+	}
+
+	for _, opt := range opts {
+		opt(req)
+	}
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		if !allowDialError || !IsDialError(err) {
+			t.Errorf("Error making GET request: %v", err)
+		}
+		return nil
+	}
+
+	defer resp.Body.Close()
+
+	if resp != nil {
+		for _, e := range responseExpectations {
+			if err := e(resp); err != nil {
+				t.Errorf("Error meeting response expectations: %v", err)
+				DumpResponse(t, resp)
+				return nil
+			}
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Errorf("Unable to read response body: %v", err)
+				DumpResponse(t, resp)
+				return nil
+			}
+			ri := &types.RuntimeInfo{}
+			if err := json.Unmarshal(b, ri); err != nil {
+				t.Errorf("Unable to parse runtime image's response payload: %v", err)
+				return nil
+			}
+			return ri
+		}
+	}
+	return nil
+}
+
+func DumpResponse(t *testing.T, resp *http.Response) {
+	t.Helper()
+	b, err := httputil.DumpResponse(resp, true)
+	if err != nil {
+		t.Errorf("Error dumping response: %v", err)
+	}
+	t.Log(string(b))
+}
+
+func StatusCodeExpectation(statusCodes sets.Int) ResponseExpectation {
+	return func(response *http.Response) error {
+		if !statusCodes.Has(response.StatusCode) {
+			return fmt.Errorf("got unexpected status: %d, expected %v", response.StatusCode, statusCodes)
+		}
+		return nil
+	}
+}
+
+func IsDialError(err error) bool {
+	if err, ok := err.(*url.Error); ok {
+		err, ok := err.Err.(*net.OpError)
+		return ok && err.Op == "dial"
+	}
+	return false
+}

--- a/test/conformance/ingress/visibility_test.go
+++ b/test/conformance/ingress/visibility_test.go
@@ -1,0 +1,371 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/pool"
+	"knative.dev/serving/pkg/apis/networking"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+func TestVisibility(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	// Create the private backend
+	name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	privateServiceName := test.ObjectNameForTest(t)
+	privateHostName := privateServiceName + "." + test.ServingNamespace + ".svc.cluster.local"
+	ingress, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{privateHostName},
+			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	// Ensure the service is not publicly accessible
+	RuntimeRequestWithExpectations(t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
+
+	loadbalancerAddress := ingress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
+	proxyName, proxyPort, cancel := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
+	defer cancel()
+
+	publicHostName := "publicproxy.example.com"
+	_, client, cancel = CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{publicHostName},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      proxyName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(proxyPort),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	// Ensure the service is accessible from within the cluster.
+	RuntimeRequest(t, client, "http://"+publicHostName)
+}
+
+func TestVisibilitySplit(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	// Use a post-split injected header to establish which split we are sending traffic to.
+	const headerName = "Foo-Bar-Baz"
+
+	backends := make([]v1alpha1.IngressBackendSplit, 0, 10)
+	weights := make(map[string]float64, len(backends))
+
+	// Double the percentage of the split each iteration until it would overflow, and then
+	// give the last route the remainder.
+	percent, total := 1, 0
+	for i := 0; i < 10; i++ {
+		name, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+		defer cancel()
+		backends = append(backends, v1alpha1.IngressBackendSplit{
+			IngressBackend: v1alpha1.IngressBackend{
+				ServiceName:      name,
+				ServiceNamespace: test.ServingNamespace,
+				ServicePort:      intstr.FromInt(port),
+			},
+			// Append different headers to each split, which lets us identify
+			// which backend we hit.
+			AppendHeaders: map[string]string{
+				headerName: name,
+			},
+			Percent: percent,
+		})
+		weights[name] = float64(percent)
+
+		total += percent
+		percent *= 2
+		// Cap the final non-zero bucket so that we total 100%
+		// After that, this will zero out remaining buckets.
+		if total+percent > 100 {
+			percent = 100 - total
+		}
+	}
+
+	name := test.ObjectNameForTest(t)
+
+	// Create a simple Ingress over the 10 Services.
+	privateHostName := fmt.Sprintf("%s.%s.%s", name, test.ServingNamespace, "svc.cluster.local")
+	localIngress, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{privateHostName},
+			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: backends,
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	// Ensure we can't connect to the private resources
+	RuntimeRequestWithExpectations(t, client, "http://"+privateHostName, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
+
+	loadbalancerAddress := localIngress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
+	proxyName, proxyPort, cancel := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
+	defer cancel()
+
+	publicHostName := fmt.Sprintf("%s.%s", name, "example.com")
+	_, client, cancel = CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{publicHostName},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      proxyName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(proxyPort),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	// Create a large enough population of requests that we can reasonably assess how
+	// well the Ingress respected the percentage split.
+	seen := make(map[string]float64, len(backends))
+
+	const (
+		// The total number of requests to make (as a float to avoid conversions in later computations).
+		totalRequests = 1000.0
+		// The increment to make for each request, so that the values of seen reflect the
+		// percentage of the total number of requests we are making.
+		increment = 100.0 / totalRequests
+		// Allow the Ingress to be within 10% of the configured value.
+		margin = 10.0
+	)
+	wg := pool.New(8)
+	resultCh := make(chan string, totalRequests)
+
+	for i := 0.0; i < totalRequests; i++ {
+		wg.Go(func() error {
+			ri := RuntimeRequest(t, client, "http://"+publicHostName)
+			if ri == nil {
+				return errors.New("failed to request")
+			}
+			resultCh <- ri.Request.Headers.Get(headerName)
+			return nil
+		})
+	}
+	if err := wg.Wait(); err != nil {
+		t.Errorf("Error while sending requests: %v", err)
+	}
+	close(resultCh)
+
+	for r := range resultCh {
+		seen[r] += increment
+	}
+
+	for name, want := range weights {
+		got := seen[name]
+		switch {
+		case want == 0.0 && got > 0.0:
+			// For 0% targets, we have tighter requirements.
+			t.Errorf("Target %q received traffic, wanted none (0%% target).", name)
+		case math.Abs(got-want) > margin:
+			t.Errorf("Target %q received %f%%, wanted %f +/- %f", name, got, want, margin)
+		}
+	}
+}
+
+func TestVisibilityPath(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	// For /foo
+	fooName, fooPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	// For /bar
+	barName, barPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	// For /baz
+	bazName, bazPort, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	mainName, port, cancel := CreateRuntimeService(t, clients, networking.ServicePortNameHTTP1)
+	defer cancel()
+
+	// Use a post-split injected header to establish which split we are sending traffic to.
+	const headerName = "Which-Backend"
+
+	name := test.ObjectNameForTest(t)
+	privateHostName := fmt.Sprintf("%s.%s.%s", name, test.ServingNamespace, "svc.cluster.local")
+	localIngress, client, cancel := CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{privateHostName},
+			Visibility: v1alpha1.IngressVisibilityClusterLocal,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Path: "/foo",
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      fooName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(fooPort),
+						},
+						// Append different headers to each split, which lets us identify
+						// which backend we hit.
+						AppendHeaders: map[string]string{
+							headerName: fooName,
+						},
+						Percent: 100,
+					}},
+				}, {
+					Path: "/bar",
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      barName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(barPort),
+						},
+						// Append different headers to each split, which lets us identify
+						// which backend we hit.
+						AppendHeaders: map[string]string{
+							headerName: barName,
+						},
+						Percent: 100,
+					}},
+				}, {
+					Path: "/baz",
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      bazName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(bazPort),
+						},
+						// Append different headers to each split, which lets us identify
+						// which backend we hit.
+						AppendHeaders: map[string]string{
+							headerName: bazName,
+						},
+						Percent: 100,
+					}},
+				}, {
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      mainName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+						// Append different headers to each split, which lets us identify
+						// which backend we hit.
+						AppendHeaders: map[string]string{
+							headerName: mainName,
+						},
+						Percent: 100,
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	// Ensure we can't connect to the private resources
+	for _, path := range []string{"", "/foo", "/bar", "/baz"} {
+		RuntimeRequestWithExpectations(t, client, "http://"+privateHostName+path, []ResponseExpectation{StatusCodeExpectation(sets.NewInt(http.StatusNotFound))}, true)
+	}
+
+	loadbalancerAddress := localIngress.Status.PrivateLoadBalancer.Ingress[0].DomainInternal
+	proxyName, proxyPort, cancel := CreateProxyService(t, clients, privateHostName, loadbalancerAddress)
+	defer cancel()
+
+	publicHostName := fmt.Sprintf("%s.%s", name, "example.com")
+	_, client, cancel = CreateIngressReady(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{publicHostName},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      proxyName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(proxyPort),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	tests := map[string]string{
+		"/foo":  fooName,
+		"/bar":  barName,
+		"/baz":  bazName,
+		"":      mainName,
+		"/asdf": mainName,
+	}
+
+	for path, want := range tests {
+		t.Run(path, func(t *testing.T) {
+			ri := RuntimeRequest(t, client, "http://"+publicHostName+path)
+			if ri == nil {
+				return
+			}
+
+			got := ri.Request.Headers.Get(headerName)
+			if got != want {
+				t.Errorf("Header[%q] = %q, wanted %q", headerName, got, want)
+			}
+		})
+	}
+}

--- a/test/conformance/ingress/websocket_test.go
+++ b/test/conformance/ingress/websocket_test.go
@@ -1,0 +1,203 @@
+// +build e2e
+
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gorilla/websocket"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/test"
+)
+
+// TestWebsocket verifies that websockets may be used via a simple Ingress.
+func TestWebsocket(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	const suffix = "- pong"
+	name, port, cancel := CreateWebsocketService(t, clients, suffix)
+	defer cancel()
+
+	domain := name + ".example.com"
+
+	// Create a simple Ingress over the Service.
+	_, dialCtx, cancel := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{domain},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      name,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(port),
+						},
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	dialer := websocket.Dialer{
+		NetDialContext:   dialCtx,
+		Proxy:            http.ProxyFromEnvironment,
+		HandshakeTimeout: 45 * time.Second,
+	}
+
+	u := url.URL{Scheme: "ws", Host: domain, Path: "/"}
+	conn, _, err := dialer.Dial(u.String(), http.Header{"Host": {domain}})
+	if err != nil {
+		t.Fatal("Dial() =", err)
+	}
+	defer conn.Close()
+
+	for i := 0; i < 100; i++ {
+		checkWebsocketRoundTrip(t, conn, suffix)
+	}
+}
+
+// TestWebsocketSplit verifies that websockets may be used across a traffic split.
+func TestWebsocketSplit(t *testing.T) {
+	t.Parallel()
+	clients := test.Setup(t)
+
+	const suffixBlue = "- blue"
+	blueName, bluePort, cancel := CreateWebsocketService(t, clients, suffixBlue)
+	defer cancel()
+
+	const suffixGreen = "- green"
+	greenName, greenPort, cancel := CreateWebsocketService(t, clients, suffixGreen)
+	defer cancel()
+
+	// The suffixes we expect to see.
+	want := sets.NewString(suffixBlue, suffixGreen)
+
+	// Create a simple Ingress over the Service.
+	name := test.ObjectNameForTest(t)
+	domain := name + ".example.com"
+	_, dialCtx, cancel := CreateIngressReadyDialContext(t, clients, v1alpha1.IngressSpec{
+		Rules: []v1alpha1.IngressRule{{
+			Hosts:      []string{domain},
+			Visibility: v1alpha1.IngressVisibilityExternalIP,
+			HTTP: &v1alpha1.HTTPIngressRuleValue{
+				Paths: []v1alpha1.HTTPIngressPath{{
+					Splits: []v1alpha1.IngressBackendSplit{{
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      blueName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(bluePort),
+						},
+						Percent: 50,
+					}, {
+						IngressBackend: v1alpha1.IngressBackend{
+							ServiceName:      greenName,
+							ServiceNamespace: test.ServingNamespace,
+							ServicePort:      intstr.FromInt(greenPort),
+						},
+						Percent: 50,
+					}},
+				}},
+			},
+		}},
+	})
+	defer cancel()
+
+	dialer := websocket.Dialer{
+		NetDialContext:   dialCtx,
+		Proxy:            http.ProxyFromEnvironment,
+		HandshakeTimeout: 45 * time.Second,
+	}
+	u := url.URL{Scheme: "ws", Host: domain, Path: "/"}
+
+	const maxRequests = 100
+	got := sets.NewString()
+	for i := 0; i < maxRequests; i++ {
+		conn, _, err := dialer.Dial(u.String(), http.Header{"Host": {domain}})
+		if err != nil {
+			t.Fatal("Dial() =", err)
+		}
+		defer conn.Close()
+
+		suffix := findWebsocketSuffix(t, conn)
+		if suffix == "" {
+			continue
+		}
+		got.Insert(suffix)
+
+		for j := 0; j < 10; j++ {
+			checkWebsocketRoundTrip(t, conn, suffix)
+		}
+
+		if want.Equal(got) {
+			// Short circuit if we've seen all splits.
+			return
+		}
+	}
+
+	// Us getting here means we haven't seen splits.
+	t.Errorf("(over %d requests) (-want, +got) = %s", maxRequests, cmp.Diff(want, got))
+}
+
+func findWebsocketSuffix(t *testing.T, conn *websocket.Conn) string {
+	// Establish the suffix that corresponds to this socket.
+	message := fmt.Sprintf("ping - %d", rand.Intn(1000))
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(message)); err != nil {
+		t.Errorf("WriteMessage() = %v", err)
+		return ""
+	}
+
+	_, recv, err := conn.ReadMessage()
+	if err != nil {
+		t.Errorf("ReadMessage() = %v", err)
+		return ""
+	}
+	gotMsg := string(recv)
+	if !strings.HasPrefix(gotMsg, message) {
+		t.Errorf("ReadMessage() = %s, wanted %s prefix", gotMsg, message)
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(gotMsg, message))
+}
+
+func checkWebsocketRoundTrip(t *testing.T, conn *websocket.Conn, suffix string) {
+	message := fmt.Sprintf("ping - %d", rand.Intn(1000))
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(message)); err != nil {
+		t.Errorf("WriteMessage() = %v", err)
+		return
+	}
+
+	// Read back the echoed message and compared with sent.
+	if _, recv, err := conn.ReadMessage(); err != nil {
+		t.Errorf("ReadMessage() = %v", err)
+	} else if got, want := string(recv), message+" "+suffix; got != want {
+		t.Errorf("ReadMessage() = %s, wanted %s", got, want)
+	}
+}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -21,7 +21,7 @@ source $(dirname $0)/e2e-common.sh
 initialize $@  --skip-istio-addon
 
 go_test_e2e -timeout=20m -parallel=12 \
-	    ./vendor/knative.dev/serving/test/conformance/ingress \
+	    ./test/conformance/ingress \
             `# TODO(#12): TestUpdate is consistently failing.` \
 	     -run="Test[^U]" \
 	    --ingressClass=contour.ingress.networking.knative.dev || fail_test

--- a/vendor/knative.dev/pkg/pool/doc.go
+++ b/vendor/knative.dev/pkg/pool/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pool contains a simple threadpool implementation that accepts
+// work in the form of `func() error` function.  The intent is for it to
+// support similar workloads to errgroup, but with a maximum number of
+// concurrent worker threads.
+package pool

--- a/vendor/knative.dev/pkg/pool/interface.go
+++ b/vendor/knative.dev/pkg/pool/interface.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"golang.org/x/sync/errgroup"
+)
+
+// Interface defines an errgroup-compatible interface for interacting with
+// our threadpool.
+type Interface interface {
+	// Go queues a single unit of work for execution on this pool. All calls
+	// to Go must be finished before Wait is called.
+	Go(func() error)
+
+	// Wait blocks until all work is complete, returning the first
+	// error returned by any of the work.
+	Wait() error
+}
+
+// errgroup.Group implements Interface
+var _ Interface = (*errgroup.Group)(nil)

--- a/vendor/knative.dev/pkg/pool/pool.go
+++ b/vendor/knative.dev/pkg/pool/pool.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pool
+
+import (
+	"context"
+	"sync"
+)
+
+type impl struct {
+	wg     sync.WaitGroup
+	workCh chan func() error
+
+	// Ensure that we Wait exactly once and memoize
+	// the result.
+	waitOnce sync.Once
+
+	cancel context.CancelFunc
+
+	// We're only interested in the first result so
+	// only set it once.
+	resultOnce sync.Once
+	result     error
+}
+
+// impl implements Interface
+var _ Interface = (*impl)(nil)
+
+// defaultCapacity is the number of work items or errors that we
+// can queue up before calls to Go will block, or work will
+// block until Wait is called.
+const defaultCapacity = 50
+
+// New creates a fresh worker pool with the specified size.
+func New(workers int) Interface {
+	return NewWithCapacity(workers, defaultCapacity)
+}
+
+// NewWithCapacity creates a fresh worker pool with the specified size.
+func NewWithCapacity(workers, capacity int) Interface {
+	i, _ := NewWithContext(context.Background(), workers, capacity)
+	return i
+}
+
+// NewWithContext creates a pool that is driven by a cancelable context.
+// Just like errgroup.Group on first error the context will be canceled as well.
+func NewWithContext(ctx context.Context, workers, capacity int) (Interface, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	i := &impl{
+		cancel: cancel,
+		workCh: make(chan func() error, capacity),
+	}
+
+	// Start a go routine for each worker, which:
+	// 1. reads off of the work channel,
+	// 2. (optionally) sets the error as the result,
+	// 3. marks work as done in our sync.WaitGroup.
+	for idx := 0; idx < workers; idx++ {
+		go func() {
+			for work := range i.workCh {
+				i.exec(work)
+			}
+		}()
+	}
+	return i, ctx
+}
+
+func (i *impl) exec(w func() error) {
+	defer i.wg.Done()
+	if err := w(); err != nil {
+		i.resultOnce.Do(func() {
+			if i.cancel != nil {
+				i.cancel()
+			}
+			i.result = err
+		})
+	}
+}
+
+// Go implements Interface.
+func (i *impl) Go(w func() error) {
+	// Increment the amount of outstanding work we're waiting on.
+	i.wg.Add(1)
+	// Send the work along the queue.
+	i.workCh <- w
+}
+
+// Wait implements Interface.
+func (i *impl) Wait() error {
+	i.waitOnce.Do(func() {
+		// Wait for queued work to complete.
+		i.wg.Wait()
+		// Notify the context, that it's done now.
+		if i.cancel != nil {
+			i.cancel()
+		}
+
+		// Now we know there are definitely no new items arriving.
+		close(i.workCh)
+	})
+
+	return i.result
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,6 +160,7 @@ github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 # github.com/gorilla/websocket v1.4.0
+## explicit
 github.com/gorilla/websocket
 # github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 github.com/grpc-ecosystem/go-grpc-prometheus
@@ -372,6 +373,7 @@ google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/googleapis/type/calendarperiod
 google.golang.org/genproto/protobuf/field_mask
 # google.golang.org/grpc v1.28.1
+## explicit
 google.golang.org/grpc
 google.golang.org/grpc/attributes
 google.golang.org/grpc/backoff
@@ -835,6 +837,7 @@ knative.dev/pkg/metrics
 knative.dev/pkg/metrics/metricskey
 knative.dev/pkg/network
 knative.dev/pkg/network/prober
+knative.dev/pkg/pool
 knative.dev/pkg/profiling
 knative.dev/pkg/ptr
 knative.dev/pkg/reconciler


### PR DESCRIPTION
To work around issue found in https://github.com/knative/net-contour/pull/121#issuecomment-630813390 , we just keep a copy of conformance ingress test.

This is a short term work around to make the nightly job passes.