### PR TITLE
Run `yq` dependency from vendor rather than `go get` and `go install`

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -64,15 +64,7 @@ rm -rf $(find vendor/ -path '*/e2e/*_test.go')
 # Add permission for shell scripts
 chmod +x $(find vendor -type f -name '*.sh')
 
-function install_yq() {
-  if [ -x "$(command -v yq)" ]; then
-    return
-  fi
-  go get github.com/mikefarah/yq/v3
-}
-
-# install yq
-install_yq
+go install ${ROOT_DIR}/vendor/github.com/mikefarah/yq/v3
 
 function add_ingress_provider_labels() {
   sed '${/---/d;}' | yq m - ./hack/labels.yaml -d "*"

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -64,10 +64,8 @@ rm -rf $(find vendor/ -path '*/e2e/*_test.go')
 # Add permission for shell scripts
 chmod +x $(find vendor -type f -name '*.sh')
 
-go install ${ROOT_DIR}/vendor/github.com/mikefarah/yq/v3
-
 function add_ingress_provider_labels() {
-  sed '${/---/d;}' | yq m - ./hack/labels.yaml -d "*"
+  sed '${/---/d;}' | go run ${ROOT_DIR}/vendor/github.com/mikefarah/yq/v3 m - ./hack/labels.yaml -d "*"
 }
 
 function delete_contour_cluster_role_bindings() {
@@ -164,4 +162,3 @@ KO_DOCKER_REPO=ko.local ko resolve -f ./vendor/github.com/projectcontour/contour
   | rewrite_serve_args contour-external \
   | rewrite_image | rewrite_command | disable_hostport \
   | add_ingress_provider_labels >> config/contour/external.yaml
-


### PR DESCRIPTION
We don't need the version to keep updating.

This also works around the issue with failing nightly builds as it was complaining about dependency not being marked explicit.

See slack: https://knative.slack.com/archives/C012J5TCS6Q/p1591062361000800 for more details about the CI failures.